### PR TITLE
Adds example for OperationProcessor

### DIFF
--- a/tests/dummy-app/app.ts
+++ b/tests/dummy-app/app.ts
@@ -11,6 +11,7 @@ import Article from "./resources/article";
 import User from "./resources/user";
 import Comment from "./resources/comment";
 import Vote from "./resources/vote";
+import Random from "./resources/random";
 
 import knexfile from "./../data/knexfile";
 import login from "./callbacks/login";
@@ -18,11 +19,12 @@ import login from "./callbacks/login";
 import UserProcessor from "./processors/user";
 import ArticleProcessor from "./processors/article";
 import VoteProcessor from "./processors/vote";
+import RandomProcessor from "./processors/random";
 
 const app = new Application({
   namespace: "api",
-  types: [Article, Comment, Vote],
-  processors: [ArticleProcessor, VoteProcessor],
+  types: [Article, Comment, Vote, Random],
+  processors: [ArticleProcessor, VoteProcessor, RandomProcessor],
   defaultProcessor: KnexProcessor
 });
 

--- a/tests/dummy-app/processors/random.ts
+++ b/tests/dummy-app/processors/random.ts
@@ -1,0 +1,24 @@
+import Random from "../resources/random";
+import { OperationProcessor, HasId, Operation } from "../jsonapi-ts";
+import jsonApiErrors from "../../../src/errors/json-api-errors";
+
+const randomDataGenerator = {
+  number: () => ({ randomNumber: Math.random() }),
+  string: () => ({ randomString: parseInt(Math.random().toString().split(".")[1]).toString(16) }),
+  date: () => ({ randomDate: new Date(1602518929 + Math.random() * 10000000000000).toJSON() })
+}
+
+export default class RandomProcessor<ResourceT extends Random> extends OperationProcessor<ResourceT> {
+  static resourceClass = Random;
+
+  async get(op: Operation): Promise<HasId | HasId[]> {
+    if (op.ref.id in randomDataGenerator) {
+      return {
+        id: op.ref.id,
+        ...randomDataGenerator[op.ref.id]()
+      }
+    } else {
+      throw jsonApiErrors.BadRequest(`Allowed random data generators: ${Object.keys(randomDataGenerator).join(", ")}`);
+    }
+  }
+}

--- a/tests/dummy-app/resources/random.ts
+++ b/tests/dummy-app/resources/random.ts
@@ -1,0 +1,12 @@
+import { Resource } from "../jsonapi-ts";
+
+export default class Random extends Resource {
+  static schema = {
+    attributes: {
+      randomString: String,
+      randomNumber: Number,
+      randomDate: String
+    },
+    relationships: {}
+  };
+}


### PR DESCRIPTION
Tested #214 and the error is no longer reproducing, so this PR adds an example of how to use an OperationProcessor-driven resource next to other KnexProcessor-based resources.

Resolves #214.