### PR TITLE
Adds NoOpTransaction for Knexless operations

### DIFF
--- a/src/application-instance.ts
+++ b/src/application-instance.ts
@@ -4,14 +4,14 @@ import * as Knex from "knex";
 import Application from "./application";
 import Resource from "./resource";
 import OperationProcessor from "./processors/operation-processor";
-import { Operation, OperationResponse } from "./types";
+import { Operation, OperationResponse, NoOpTransaction } from "./types";
 import jsonApiErrors from "./errors/json-api-errors";
 import User from "./resources/user";
 import JsonApiError from "./errors/error";
 
 export default class ApplicationInstance {
   public user: User;
-  public transaction: Knex.Transaction;
+  public transaction: Knex.Transaction | NoOpTransaction;
 
   constructor(public app: Application) { }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -6,7 +6,7 @@ import KnexProcessor from "./processors/knex-processor";
 import OperationProcessor from "./processors/operation-processor";
 import Resource from "./resource";
 import JsonApiSerializer from "./serializers/serializer";
-import { AddonOptions, ApplicationAddons, ApplicationServices, IJsonApiSerializer, Operation, OperationResponse, ResourceSchemaRelationship } from "./types";
+import { AddonOptions, ApplicationAddons, ApplicationServices, IJsonApiSerializer, Operation, OperationResponse, ResourceSchemaRelationship, NoOpTransaction } from "./types";
 import flatten from "./utils/flatten";
 
 export default class Application {
@@ -141,11 +141,14 @@ export default class Application {
     return this.buildOperationResponse(result, processor.appInstance);
   }
 
-  async createTransaction(): Promise<Knex.Transaction | undefined> {
+  async createTransaction(): Promise<Knex.Transaction | NoOpTransaction> {
     const { knex }: { knex?: Knex } = this.services;
 
     if (!knex) {
-      return;
+      return {
+        commit: () => { },
+        rollback: () => { }
+      }
     }
 
     return new Promise(resolve =>

--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -84,7 +84,7 @@ export default class KnexProcessor<ResourceT extends Resource> extends Operation
 
   constructor(appInstance: ApplicationInstance) {
     super(appInstance);
-    this.knex = appInstance.transaction;
+    this.knex = appInstance.transaction as Knex.Transaction;
   }
 
   getQuery(): Knex.QueryBuilder {
@@ -357,7 +357,7 @@ export default class KnexProcessor<ResourceT extends Resource> extends Operation
     if (!op.params || !op.params.include) {
       return {};
     }
-    
+
     return eagerLoadedData;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,3 +191,8 @@ export interface IAddon {
 }
 export type AddonOptions = { [key: string]: any };
 export type ApplicationAddons = { addon: typeof Addon; options: AddonOptions }[];
+
+export type NoOpTransaction = {
+  commit(): void;
+  rollback(): void;
+}


### PR DESCRIPTION
Resolves #215.

This PR implements the solution described in the issue, by creating a `NoOpTransaction` type and adding it as a possible type wherever `transaction` is instantiated.