### PR TITLE
Allows extending ResourceSchema types by turning them into interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kurier",
-  "version": "1.0.0-alpha3",
+  "version": "1.0.0-alpha4",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kurier",
-  "version": "1.0.0-alpha1",
+  "version": "1.0.0-alpha3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kurier",
-  "version": "1.0.0-alpha4",
+  "version": "1.0.0-alpha5",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,7 @@ export type AttributeValueMatch = {
   operator?: "not" | "some" | "every";
 };
 
-export type ResourceSchema = {
+export interface ResourceSchema {
   primaryKeyName?: string;
   attributes: ResourceSchemaAttributes;
   relationships: ResourceSchemaRelationships;
@@ -134,7 +134,7 @@ export type ResourceSchema = {
 
 export type PasswordConstructor = typeof Password;
 
-export type ResourceSchemaAttributes = {
+export interface ResourceSchemaAttributes {
   [key: string]:
     | StringConstructor
     | NumberConstructor
@@ -148,7 +148,7 @@ export type ResourceSchemaRelationships = {
   [key: string]: ResourceSchemaRelationship;
 };
 
-export type ResourceSchemaRelationship = {
+export interface ResourceSchemaRelationship {
   type: () => typeof Resource;
   hasMany?: boolean;
   belongsTo?: boolean;


### PR DESCRIPTION
According to [this article](https://dev.to/stereobooster/typescript-type-vs-interface-2n0c), `type` is closed to extension. Addons are impaired to extend relationship-related functionality. 

This PR changes ResourceSchema* definitions to become interfaces.