### PR TITLE
Fix/issue 183 included

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -209,7 +209,7 @@ export default class Application {
         return new Promise(async resolve => {
           const result = await canAccessResource(resource, "get", appInstance);
 
-          if (result && !resource.preventSerialization) {
+          if (result) {
             included.push(resource);
           }
 

--- a/src/serializers/serializer.ts
+++ b/src/serializers/serializer.ts
@@ -161,6 +161,8 @@ export default class JsonApiSerializer implements IJsonApiSerializer {
       return data.map(record => this.serializeIncludedResources(record, resourceType));
     }
 
+    if (data.preventSerialization) { return [] }
+
     const schemaRelationships = resourceType.schema.relationships;
     const includedData = [];
 


### PR DESCRIPTION
I think this solves the issue that I commented [here](https://github.com/kurierjs/kurier/pull/235#issuecomment-724275303).
The issue was that even though you checked the prop [here](https://github.com/kurierjs/kurier/pull/235/commits/06bc58085b66783a06ea9b6e040c9ba489f800c9#diff-16a8f18a1e6d24ab6125db9b965edc8d7970d184e44ada35f3ccbf71a21670a4R212), the included resources don't inherit the preventSerialization prop of their parent.

Basically, in my PR we avoid serializing all the included resources of previously filtered out parent resources.

I also removed the extra check that you added in [here](https://github.com/kurierjs/kurier/pull/235/commits/06bc58085b66783a06ea9b6e040c9ba489f800c9#diff-16a8f18a1e6d24ab6125db9b965edc8d7970d184e44ada35f3ccbf71a21670a4R212), as it's no longer necessary.