### PR TITLE
Adds support for optional relationships in schema definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ A TypeScript framework to create APIs following the [1.1 Spec of JSONAPI](https:
      static schema = {
        attributes: {
          firstName: String,
-         lastName: String
+         lastName: String,
        },
-       relationships: {}
      };
    }
    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,9 +73,8 @@ A TypeScript framework to create APIs following the [1.1 Spec of JSONAPI](https:
      static schema = {
        attributes: {
          firstName: String,
-         lastName: String
+         lastName: String,
        },
-       relationships: {}
      };
    }
 ```
@@ -725,7 +724,6 @@ export default class ReadOnlyProcessor extends OperationProcessor<Resource> {
       type: op.ref.type,
       id: basename(file),
       attributes: JSON.parse(readFileSync(file).toString()),
-      relationships: {}
     }));
   }
 }
@@ -750,7 +748,6 @@ export default class ReadOnlyProcessor extends OperationProcessor<Resource> {
           type: op.ref.type,
           id: basename(file),
           attributes,
-          relationships: {}
         };
       } catch {
         throw JsonApiErrors.UnhandledError("Error while reading file");
@@ -797,9 +794,8 @@ export default class Moment extends Resource {
   static schema = {
     attributes: {
       date: String,
-      time: String
+      time: String,
     },
-    relationships: {}
   };
 }
 ```
@@ -833,7 +829,6 @@ export default class MomentProcessor extends OperationProcessor<Moment> {
           date,
           time
         },
-        relationships: {}
       }
     ];
   }
@@ -928,7 +923,6 @@ export default class BookProcessor extends KnexProcessor<Book> {
       attributes: {
         count: (await super.get(op)).length
       },
-      relationships: {}
     };
   }
 }
@@ -1025,7 +1019,6 @@ export default class User extends JsonApiUser {
       emailAddress: String,
       passphrase: Password
     },
-    relationships: {}
   };
 }
 ```

--- a/src/application.ts
+++ b/src/application.ts
@@ -182,7 +182,13 @@ export default class Application {
   }
 
   async resourceFor(resourceType: string): Promise<typeof Resource> {
-    return this.types.find(({ type }) => type && type === resourceType) as typeof Resource;
+    const resource = this.types.find(({ type }) => type && type === resourceType) as typeof Resource;
+
+    if (!resource.schema.relationships) {
+      resource.schema.relationships = {};
+    }
+
+    return resource;
   }
 
   async buildOperationResponse(


### PR DESCRIPTION
Resolves #232.

Some basic resources, such as classificators (i.e. resources with nothing more than an ID and a name), don't need to have relationships specified.

This PR modifies `resourceFor` to insert an empty (`{}`) object for `resource.schema.relationships` in case the definition doesn't include it.

This change has no impact on the `ResourceSchema` definition, since `relationships` will continue to be mandatory (otherwise, we'd have lots of `| undefined` casts to resolve, and that seemed like a lot of changes for a minor DX improvement).