### PR TITLE
Adds `strict` mode for HTTP transport layers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1291,7 +1291,11 @@ import Author from "./resources/author";
 const app = new Application({
   namespace: "api",
   types: [Author],
-  defaultProcessor: new KnexProcessor(/* knex options */)
+  defaultProcessor: new KnexProcessor(/* knex options */),
+  transportLayerOptions: {
+    httpBodyPayload: '1mb',
+    httpStrictMode: true
+  },
 });
 
 const api = new Koa();
@@ -1307,6 +1311,9 @@ The `Application` object is instantiated with the following settings:
 - `types`: A list of all resource types declared and handled by this app.
 - `processors`: If you define custom processors, they have to be registered here as instances.
 - `defaultProcessor`: All non-bound-to-processor resources will be handled by this processor.
+- `transportLayerOptions`: Allows to customize some aspects of the transport layer used by the application.
+  - `httpBodyPayload`: Describes how big the request's `body` can be, expressed in a string i.e. `10mb`. Defaults to `1mb`.
+  - `httpStrictMode`: If enabled, requires all HTTP incoming requests to use `Content-Type: application/vnd.api+json`. Defaults to `false`.
 
 ### Referencing types and processors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kurier",
-  "version": "1.2.0-alpha2",
+  "version": "1.2.0-alpha3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/application.ts
+++ b/src/application.ts
@@ -36,7 +36,8 @@ export default class Application {
     this.addons = [];
     this.serializer = new (settings.serializer || JsonApiSerializer)();
     this.transportLayerOptions = settings.transportLayerOptions || {
-      httpBodyPayload: '1mb'
+      httpBodyPayload: '1mb',
+      strictMode: false
     };
   }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -37,7 +37,7 @@ export default class Application {
     this.serializer = new (settings.serializer || JsonApiSerializer)();
     this.transportLayerOptions = settings.transportLayerOptions || {
       httpBodyPayload: '1mb',
-      strictMode: false
+      httpStrictMode: false
     };
   }
 

--- a/src/middlewares/json-api-express.ts
+++ b/src/middlewares/json-api-express.ts
@@ -14,7 +14,7 @@ import jsonApiErrors from "../errors/json-api-errors";
 
 export default function jsonApiExpress(app: Application, ...middlewares: express.RequestHandler[]) {
   const checkStrictMode = async (req: express.Request, res: express.Response, next: () => any) => {
-    if (!app.transportLayerOptions.strictMode) {
+    if (!app.transportLayerOptions.httpStrictMode) {
       return next();
     }
 
@@ -51,7 +51,7 @@ export default function jsonApiExpress(app: Application, ...middlewares: express
   return compose([
     checkStrictMode,
     express.json({
-      type: app.transportLayerOptions?.strictMode
+      type: app.transportLayerOptions?.httpStrictMode
         ? 'application/vnd.api+json'
         : 'application/json',
       strict: false,

--- a/src/middlewares/json-api-koa.ts
+++ b/src/middlewares/json-api-koa.ts
@@ -14,7 +14,7 @@ import jsonApiErrors from "../errors/json-api-errors";
 
 export default function jsonApiKoa(app: Application, ...middlewares: Middleware[]) {
   const checkStrictMode = async (ctx: Context, next: () => Promise<any>) => {
-    if (!app.transportLayerOptions.strictMode) {
+    if (!app.transportLayerOptions.httpStrictMode) {
       return next();
     }
 

--- a/src/middlewares/json-api-vercel.ts
+++ b/src/middlewares/json-api-vercel.ts
@@ -16,7 +16,7 @@ import {
 import jsonApiErrors from "../errors/json-api-errors";
 
 const checkStrictMode = async (app: Application, req: VercelRequest, res: VercelResponse) => {
-  if (!app.transportLayerOptions.strictMode) {
+  if (!app.transportLayerOptions.httpStrictMode) {
     return;
   }
 

--- a/src/middlewares/json-api-vercel.ts
+++ b/src/middlewares/json-api-vercel.ts
@@ -13,13 +13,28 @@ import {
   convertErrorToHttpResponse
 } from "../utils/http-utils";
 
+import jsonApiErrors from "../errors/json-api-errors";
+
+const checkStrictMode = async (app: Application, req: VercelRequest, res: VercelResponse) => {
+  if (!app.transportLayerOptions.strictMode) {
+    return;
+  }
+
+  if (req.headers["content-type"] !== 'application/vnd.api+json') {
+    res.status(400);
+    res.send(convertErrorToHttpResponse(jsonApiErrors.BadRequest("Content-Type must be application/vnd.api+json")));
+  } else {
+    // Vercel's magic body parser is limited to certain MIME types. The JSONAPI MIME type isn't one of them.
+    // As a result, `req.body` becomes undefined. So, we trick Vercel into thinking this is an `application/json`
+    // request, and keep parsing the data as JSON.
+    req.headers["content-type"] = 'application/json';
+  }
+};
+
 export default function jsonApiVercel(app: Application) {
   return async (req: VercelRequest, res: VercelResponse) => {
+    await checkStrictMode(app, req, res);
     const appInstance = new ApplicationInstance(app);
-
-    if (['POST', 'PUT', 'PATCH'].includes(req.method!) && typeof req.body === 'string') {
-      req.body = JSON.parse(req.body);
-    }
 
     try {
       await authenticate(appInstance, req);

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,7 @@ export type NoOpTransaction = {
 
 export type TransportLayerOptions = {
   httpBodyPayload?: string;
+  strictMode?: boolean;
 }
 
 export type VercelRequest<BodyType = JsonApiDocument> = IncomingMessage & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,7 +208,7 @@ export type NoOpTransaction = {
 
 export type TransportLayerOptions = {
   httpBodyPayload?: string;
-  strictMode?: boolean;
+  httpStrictMode?: boolean;
 }
 
 export type VercelRequest<BodyType = JsonApiDocument> = IncomingMessage & {

--- a/tests/test-suite/acceptance/helpers/transportLayers.ts
+++ b/tests/test-suite/acceptance/helpers/transportLayers.ts
@@ -24,10 +24,13 @@ const transportLayerContext = {
 export const transportLayers = Object.keys(transportLayerContext).map(layer => [layer]);
 
 export default function testTransportLayer(transportLayer?: string) {
-  const { app, agent }= transportLayerContext[transportLayer];
+  const { app, agent } = transportLayerContext[transportLayer];
   const request = superagentDefaults(agent(app));
 
   request.use(supertestPrefix(`/${kurierApp.namespace}`));
+  request.use((req: supertest.Request) => {
+    req.set("Content-Type", "application/vnd.api+json");
+  });
 
   return request;
 }

--- a/tests/test-suite/test-app/app.ts
+++ b/tests/test-suite/test-app/app.ts
@@ -28,7 +28,7 @@ const app = new Application({
   processors: [ArticleProcessor, VoteProcessor, RandomProcessor],
   defaultProcessor: KnexProcessor,
   transportLayerOptions: {
-    strictMode: true,
+    httpStrictMode: true,
   }
 });
 

--- a/tests/test-suite/test-app/app.ts
+++ b/tests/test-suite/test-app/app.ts
@@ -26,7 +26,10 @@ const app = new Application({
   namespace: "api",
   types: [Article, Comment, Vote, Random],
   processors: [ArticleProcessor, VoteProcessor, RandomProcessor],
-  defaultProcessor: KnexProcessor
+  defaultProcessor: KnexProcessor,
+  transportLayerOptions: {
+    strictMode: true,
+  }
 });
 
 app.use(UserManagementAddon, {


### PR DESCRIPTION
Resolves #290.

As described in the issue, the JSONAPI spec requires `application/vnd.api+json` as `Content-Type` for all requests. This PR adds support for opt-in usage of the spec's header.