### PR TITLE
Fix/reduce spread reduce

### DIFF
--- a/src/processors/operation-processor.ts
+++ b/src/processors/operation-processor.ts
@@ -81,7 +81,7 @@ export default class OperationProcessor<ResourceT extends Resource> {
       }
       const value = directRelations[includedRelationResource];
       const computed = await resourceProcessor.getComputedProperties(op, relationResourceClass, value, {});
-      directRelations[includedRelationResource] = { ...value, ...computed };
+      Object.assign(directRelations[includedRelationResource], computed);
     }
     return directRelations;
   }

--- a/src/processors/session-processor.ts
+++ b/src/processors/session-processor.ts
@@ -19,10 +19,12 @@ export default class SessionProcessor<T extends Session> extends KnexProcessor<T
   }
 
   public async add(op: Operation): Promise<HasId> {
-    const fields = Object.keys(op.data?.attributes as { [key: string]: Function })
-      .filter((attribute) => this.resourceClass.schema.attributes[attribute] !== Password)
-      .map((attribute) => ({ [attribute]: op.data?.attributes[attribute] }))
-      .reduce((attributes, attribute) => ({ ...attributes, ...attribute }), {});
+    const fields = Object.assign(
+      {},
+      ...Object.keys(op.data?.attributes as { [key: string]: Function })
+        .filter((attribute) => this.resourceClass.schema.attributes[attribute] !== Password)
+        .map((attribute) => ({ [attribute]: op.data?.attributes[attribute] })),
+    );
 
     if (Object.keys(fields).length === 0) {
       throw jsonApiErrors.InvalidData();

--- a/src/processors/user-processor.ts
+++ b/src/processors/user-processor.ts
@@ -18,10 +18,12 @@ export default class UserProcessor<T extends User> extends KnexProcessor<T> {
   }
 
   async add(op: Operation): Promise<HasId> {
-    const fields = Object.keys(op.data?.attributes as { [key: string]: Function })
-      .filter((attribute) => this.resourceClass.schema.attributes[attribute] !== Password)
-      .map((attribute) => ({ [attribute]: op.data?.attributes[attribute] }))
-      .reduce((attributes, attribute) => ({ ...attributes, ...attribute }), {});
+    const fields = Object.assign(
+      {},
+      ...Object.keys(op.data?.attributes as { [key: string]: Function })
+        .filter((attribute) => this.resourceClass.schema.attributes[attribute] !== Password)
+        .map((attribute) => ({ [attribute]: op.data?.attributes[attribute] })),
+    );
 
     const id = await this.generateId();
 

--- a/src/processors/user-processor.ts
+++ b/src/processors/user-processor.ts
@@ -1,5 +1,5 @@
 import Authorize from "../decorators/authorize";
-import { Operation, HasId, DEFAULT_PRIMARY_KEY } from "../types";
+import { Operation, HasId } from "../types";
 import User from "../resources/user";
 import KnexProcessor from "./knex-processor";
 import Password from "../attribute-types/password";

--- a/src/utils/pick.ts
+++ b/src/utils/pick.ts
@@ -1,7 +1,9 @@
 const pick = <R = Record<string, unknown>, T = Record<string, unknown>>(object: R, list: string[] = []): T => {
   return list.reduce((acc, key) => {
     const hasProperty = key in object;
-    return hasProperty ? { ...acc, [key]: object[key] } : acc;
+    if (!hasProperty) return acc;
+    acc[key] = object[key];
+    return acc;
   }, {}) as T;
 };
 


### PR DESCRIPTION
Inspired by [this article](https://www.richsnapp.com/article/2019/06-09-reduce-spread-anti-pattern), this PR removes most if not all `reduce...spread` usage.

It would be nice to have performance tests, to test how much the performance improved, but it's late, it's an order of magnitude faster (`O(n^2)` to `O(n)`), and I don't wanna code that RN.