### PR TITLE
Support for `meta` in responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kurier",
-  "version": "1.2.2",
+  "version": "1.3.0-meta-alpha0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kurier",
-      "version": "1.2.2",
+      "version": "1.3.0-meta-alpha0",
       "license": "MIT",
       "dependencies": {
         "compose-middleware": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "trace-unhandled": "^2.0.1",
         "ts-jest": "^29.0.0",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^4.8.3",
+        "typescript": "^4.9.4",
         "vercel-node-server": "^2.2.1"
       }
     },
@@ -2074,7 +2074,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2846,9 +2846,9 @@
       }
     },
     "node_modules/dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -5211,23 +5211,26 @@
       }
     },
     "node_modules/koa-body/node_modules/formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "dependencies": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/koa-body/node_modules/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
       },
@@ -7029,30 +7032,18 @@
       }
     },
     "node_modules/superagent/node_modules/formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "dev": true,
       "dependencies": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/superagent/node_modules/formidable/node_modules/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/superagent/node_modules/mime": {
@@ -7065,6 +7056,21 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/supertest": {
@@ -7602,9 +7608,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -9560,7 +9566,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -10163,9 +10169,9 @@
       "dev": true
     },
     "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "requires": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -11976,20 +11982,23 @@
       },
       "dependencies": {
         "formidable": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-          "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+          "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
           "requires": {
-            "dezalgo": "1.0.3",
-            "hexoid": "1.0.0",
-            "once": "1.4.0",
-            "qs": "6.9.3"
+            "dezalgo": "^1.0.4",
+            "hexoid": "^1.0.0",
+            "once": "^1.4.0",
+            "qs": "^6.11.0"
           }
         },
         "qs": {
-          "version": "6.9.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },
@@ -13303,23 +13312,15 @@
           }
         },
         "formidable": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-          "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+          "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
           "dev": true,
           "requires": {
-            "dezalgo": "1.0.3",
-            "hexoid": "1.0.0",
-            "once": "1.4.0",
-            "qs": "6.9.3"
-          },
-          "dependencies": {
-            "qs": {
-              "version": "6.9.3",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-              "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
-              "dev": true
-            }
+            "dezalgo": "^1.0.4",
+            "hexoid": "^1.0.0",
+            "once": "^1.4.0",
+            "qs": "^6.11.0"
           }
         },
         "mime": {
@@ -13327,6 +13328,15 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
           "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
           "dev": true
+        },
+        "qs": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },
@@ -13717,9 +13727,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "unique-filename": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "Ryan Tablada",
     "Erik Bryn",
     "Alexey Kulakov",
-    "Maciej Kwaśniak"
+    "Maciej Kwaśniak",
+    "Renan William",
+    "Marcelo Mira"
   ],
   "license": "MIT",
   "bugs": {
@@ -38,11 +40,11 @@
     "escape-string-regexp": "^4.0.0",
     "express": "^4.18.1",
     "jsonwebtoken": "^9.0.0",
+    "inflection": "^1.13.4",
     "knex": "^2.3.0",
     "koa": "2.13.4",
     "koa-body": "^5.0.0",
     "koa-compose": "^4.1.0",
-    "inflection": "^1.13.4",
     "ws": "^8.8.1"
   },
   "devDependencies": {
@@ -69,7 +71,7 @@
     "trace-unhandled": "^2.0.1",
     "ts-jest": "^29.0.0",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^4.8.3",
+    "typescript": "^4.9.4",
     "vercel-node-server": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kurier",
-  "version": "1.2.2",
+  "version": "1.3.0-meta-alpha0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/application.ts
+++ b/src/application.ts
@@ -23,6 +23,8 @@ import flatten from "./utils/flatten";
 import { classify } from "./utils/string";
 import { isEmptyObject } from "./utils/object";
 
+const OPERATIONS_INCOMPATIBLE_WITH_META_INJECTION = ["identify"];
+
 export default class Application {
   namespace: string;
   types: typeof Resource[];
@@ -171,6 +173,10 @@ export default class Application {
     processor: OperationProcessor<Resource>,
     op: Operation,
   ): Promise<void> {
+    if (OPERATIONS_INCOMPATIBLE_WITH_META_INJECTION.includes(op.op)) {
+      return;
+    }
+
     const resourceMetaHookToCallForOperation = `resourceMetaFor${classify(op.op)}`;
     if (Array.isArray(result)) {
       for (const resource of result) {

--- a/src/application.ts
+++ b/src/application.ts
@@ -216,6 +216,10 @@ export default class Application {
       return;
     }
 
+    if (OPERATIONS_INCOMPATIBLE_WITH_META_INJECTION.includes(op.op)) {
+      return;
+    }
+
     const metaHookToCallForOperation = `metaFor${classify(op.op)}`;
     const meta = await processor.meta(data);
     const metaFor = await processor.metaFor(op, data);

--- a/src/processors/operation-processor.ts
+++ b/src/processors/operation-processor.ts
@@ -1,5 +1,5 @@
 import Resource from "../resource";
-import { HasId, Operation, EagerLoadedData } from "../types";
+import { HasId, Operation, EagerLoadedData, MaybeMeta } from "../types";
 import pick from "../utils/pick";
 import promiseHashMap from "../utils/promise-hash-map";
 import ApplicationInstance from "../application-instance";
@@ -255,4 +255,16 @@ export default class OperationProcessor<ResourceT extends Resource> {
   async add(op: Operation): Promise<HasId> {
     return Promise.reject();
   }
+
+  async meta(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {}
+  async metaFor(op: Operation, resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {}
+  async metaForGet(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {}
+  async metaForAdd(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {}
+  async metaForUpdate(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {}
+
+  async resourceMeta(resource: ResourceT): Promise<MaybeMeta> {}
+  async resourceMetaFor(op: Operation, resource: ResourceT): Promise<MaybeMeta> {}
+  async resourceMetaForGet(resource: ResourceT): Promise<MaybeMeta> {}
+  async resourceMetaForAdd(resource: ResourceT): Promise<MaybeMeta> {}
+  async resourceMetaForUpdate(resource: ResourceT): Promise<MaybeMeta> {}
 }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -34,6 +34,9 @@ export default class Resource {
     this.type = (this.constructor as typeof Resource).type;
     this.attributes = attributes || {};
     this.relationships = relationships || {};
-    this.meta = meta || {};
+
+    if (meta) {
+      this.meta = meta;
+    }
   }
 }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,4 +1,4 @@
-import { ResourceAttributes, ResourceRelationships, ResourceSchema } from "./types";
+import { Meta, ResourceAttributes, ResourceRelationships, ResourceSchema } from "./types";
 import { camelize } from "./utils/string";
 
 export default class Resource {
@@ -15,6 +15,7 @@ export default class Resource {
   type: string;
   attributes: ResourceAttributes;
   relationships: ResourceRelationships;
+  meta?: Meta;
 
   preventSerialization?: boolean;
 
@@ -22,14 +23,17 @@ export default class Resource {
     id,
     attributes,
     relationships,
+    meta,
   }: {
     id?: string;
     attributes?: ResourceAttributes;
     relationships?: ResourceRelationships;
+    meta?: Meta;
   }) {
     this.id = id;
     this.type = (this.constructor as typeof Resource).type;
     this.attributes = attributes || {};
     this.relationships = relationships || {};
+    this.meta = meta || {};
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export type Meta = {
   [key: string]: AttributeValue;
 };
 
+export type MaybeMeta = Meta | void;
+
 export type JsonApiDocument<ResourceT = Resource, RelatedResourcesT = Resource> = {
   data: ResourceT | ResourceT[];
   meta?: Meta;
@@ -116,6 +118,7 @@ export type Operation = {
 export type OperationResponse = {
   data: Resource | Resource[] | null;
   included?: Resource[];
+  meta?: Meta;
 };
 
 export type KnexRecord = {

--- a/src/utils/http-utils.ts
+++ b/src/utils/http-utils.ts
@@ -7,6 +7,7 @@ import User from "../resources/user";
 import { JsonApiDocument, JsonApiErrorsDocument, Operation, OperationResponse } from "../types";
 import { parse } from "../utils/json-api-params";
 import { camelize, singularize } from "../utils/string";
+import { isEmptyObject } from "./object";
 
 const STATUS_MAPPING = {
   GET: 200,
@@ -100,7 +101,16 @@ function convertOperationResponseToHttpResponse(
   const responseMethods = ["GET", "POST", "PATCH", "PUT"];
 
   if (responseMethods.includes(req.method as string)) {
-    return { data: operation.data, included: operation.included } as JsonApiDocument;
+    const document = {
+      data: operation.data,
+    } as JsonApiDocument;
+    if (operation.included) {
+      document.included = operation.included;
+    }
+    if (!isEmptyObject(operation.meta!)) {
+      document.meta = operation.meta;
+    }
+    return document;
   }
 }
 

--- a/src/utils/http-utils.ts
+++ b/src/utils/http-utils.ts
@@ -120,11 +120,13 @@ function convertErrorToHttpResponse(error: JsonApiError): JsonApiErrorsDocument 
 
   const jsonApiError = isJsonApiError ? error : JsonApiErrors.UnhandledError();
   if ((!process.env.NODE_ENV || process.env.NODE_ENV !== "production") && error.stack && !isJsonApiError) {
-    let firstLineErrorStack = error.stack.split("\n")[0];
-    if (firstLineErrorStack.indexOf("Error:") === 0) {
-      firstLineErrorStack = firstLineErrorStack.slice(7);
-    }
-    jsonApiError.detail = firstLineErrorStack;
+    const stackTrace = error.stack.split("\n");
+    const [firstLineErrorStack, secondLineErrorStack] = stackTrace;
+    const detail = firstLineErrorStack.startsWith("Error:") ? firstLineErrorStack.slice(7) : "";
+    jsonApiError.detail = detail;
+    jsonApiError.source = {
+      pointer: secondLineErrorStack,
+    };
   }
 
   return { errors: [jsonApiError] };

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,3 +1,3 @@
-const isEmptyObject = (obj: {}) => Object.keys(obj).length === 0;
+const isEmptyObject = (obj: any) => obj && Object.keys(obj).length === 0;
 
 export { isEmptyObject };

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,3 @@
+const isEmptyObject = (obj: {}) => Object.keys(obj).length === 0;
+
+export { isEmptyObject };

--- a/src/utils/pick.ts
+++ b/src/utils/pick.ts
@@ -1,4 +1,7 @@
-const pick = <R = Record<string, unknown>, T = Record<string, unknown>>(object: R, list: string[] = []): T => {
+const pick = <R extends object = Record<string, unknown>, T = Record<string, unknown>>(
+  object: R,
+  list: string[] = [],
+): T => {
   return list.reduce((acc, key) => {
     const hasProperty = key in object;
     if (!hasProperty) return acc;

--- a/tests/dummy-app/processors/article.ts
+++ b/tests/dummy-app/processors/article.ts
@@ -6,66 +6,6 @@ import Vote from "../resources/vote";
 export default class ArticleProcessor<ResourceT extends Article> extends KnexProcessor<ResourceT> {
   static resourceClass = Article;
 
-  async meta(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      meta: "ok",
-    };
-  }
-
-  async metaFor(op: Operation, resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      metaFor: op.op,
-    };
-  }
-
-  async metaForAdd(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      metaForAdd: "ok",
-    };
-  }
-
-  async metaForUpdate(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      metaForUpdate: "ok",
-    };
-  }
-
-  async metaForGet(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      metaForGet: "ok",
-    };
-  }
-
-  async resourceMeta(resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMeta: "ok",
-    };
-  }
-
-  async resourceMetaFor(op: Operation, resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMetaFor: op.op,
-    };
-  }
-
-  async resourceMetaForAdd(resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMetaForAdd: "ok",
-    };
-  }
-
-  async resourceMetaForUpdate(resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMetaForUpdate: "ok",
-    };
-  }
-
-  async resourceMetaForGet(resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMetaForGet: "ok",
-    };
-  }
-
   attributes = {
     async voteCount(this: ArticleProcessor<Article>, article: HasId) {
       const processor = <KnexProcessor<Vote>>await this.processorFor("vote");

--- a/tests/dummy-app/processors/article.ts
+++ b/tests/dummy-app/processors/article.ts
@@ -1,9 +1,70 @@
+import { MaybeMeta, Operation } from "../../../src";
 import { KnexProcessor, HasId } from "../kurier";
 import Article from "../resources/article";
 import Vote from "../resources/vote";
 
 export default class ArticleProcessor<ResourceT extends Article> extends KnexProcessor<ResourceT> {
   static resourceClass = Article;
+
+  async meta(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      meta: "ok",
+    };
+  }
+
+  async metaFor(op: Operation, resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      metaFor: op.op,
+    };
+  }
+
+  async metaForAdd(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      metaForAdd: "ok",
+    };
+  }
+
+  async metaForUpdate(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      metaForUpdate: "ok",
+    };
+  }
+
+  async metaForGet(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      metaForGet: "ok",
+    };
+  }
+
+  async resourceMeta(resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMeta: "ok",
+    };
+  }
+
+  async resourceMetaFor(op: Operation, resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMetaFor: op.op,
+    };
+  }
+
+  async resourceMetaForAdd(resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMetaForAdd: "ok",
+    };
+  }
+
+  async resourceMetaForUpdate(resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMetaForUpdate: "ok",
+    };
+  }
+
+  async resourceMetaForGet(resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMetaForGet: "ok",
+    };
+  }
 
   attributes = {
     async voteCount(this: ArticleProcessor<Article>, article: HasId) {

--- a/tests/test-suite/acceptance/article.test.ts
+++ b/tests/test-suite/acceptance/article.test.ts
@@ -53,6 +53,48 @@ describe.each(transportLayers)("Transport Layer: %s", (transportLayer) => {
         const result = await request.get("/articles/1?include=author");
         expect(result.body.included).toEqual(undefined);
       });
+
+      it("Meta - Get meta hooks response", async () => {
+        const result = await request.get("/articles");
+        expect(result.body.data[0].meta).toEqual({
+          resourceMetaForGet: "ok",
+          resourceMetaFor: "get",
+          resourceMeta: "ok",
+        });
+        expect(result.body.meta).toEqual({
+          metaForGet: "ok",
+          metaFor: "get",
+          meta: "ok",
+        });
+      });
+
+      it("Meta - meta hooks response in GET ALL", async () => {
+        const result = await request.get("/articles");
+        expect(result.body.data[0].meta).toEqual({
+          resourceMetaForGet: "ok",
+          resourceMetaFor: "get",
+          resourceMeta: "ok",
+        });
+        expect(result.body.meta).toEqual({
+          metaForGet: "ok",
+          metaFor: "get",
+          meta: "ok",
+        });
+      });
+
+      it("Meta - meta hooks response in GET by ID", async () => {
+        const result = await request.get("/articles/1");
+        expect(result.body.data[0].meta).toEqual({
+          resourceMetaForGet: "ok",
+          resourceMetaFor: "get",
+          resourceMeta: "ok",
+        });
+        expect(result.body.meta).toEqual({
+          metaForGet: "ok",
+          metaFor: "get",
+          meta: "ok",
+        });
+      });
     });
   });
 });

--- a/tests/test-suite/acceptance/article.test.ts
+++ b/tests/test-suite/acceptance/article.test.ts
@@ -58,13 +58,6 @@ describe.each(transportLayers)("Transport Layer: %s", (transportLayer) => {
         const result = await request.get("/articles");
         expect(result.body.data[0].meta).toEqual({
           resourceMetaForGet: "ok",
-          resourceMetaFor: "get",
-          resourceMeta: "ok",
-        });
-        expect(result.body.meta).toEqual({
-          metaForGet: "ok",
-          metaFor: "get",
-          meta: "ok",
         });
       });
 
@@ -72,27 +65,13 @@ describe.each(transportLayers)("Transport Layer: %s", (transportLayer) => {
         const result = await request.get("/articles");
         expect(result.body.data[0].meta).toEqual({
           resourceMetaForGet: "ok",
-          resourceMetaFor: "get",
-          resourceMeta: "ok",
-        });
-        expect(result.body.meta).toEqual({
-          metaForGet: "ok",
-          metaFor: "get",
-          meta: "ok",
         });
       });
 
       it("Meta - meta hooks response in GET by ID", async () => {
         const result = await request.get("/articles/1");
-        expect(result.body.data[0].meta).toEqual({
+        expect(result.body.data.meta).toEqual({
           resourceMetaForGet: "ok",
-          resourceMetaFor: "get",
-          resourceMeta: "ok",
-        });
-        expect(result.body.meta).toEqual({
-          metaForGet: "ok",
-          metaFor: "get",
-          meta: "ok",
         });
       });
     });

--- a/tests/test-suite/acceptance/factories/article.ts
+++ b/tests/test-suite/acceptance/factories/article.ts
@@ -64,6 +64,9 @@ export default {
             data: { id: 1, type: "user" },
           },
         },
+        meta: {
+          resourceMetaForGet: "ok",
+        },
       },
       {
         id: 2,
@@ -76,6 +79,9 @@ export default {
           author: {
             data: { id: 2, type: "user" },
           },
+        },
+        meta: {
+          resourceMetaForGet: "ok",
         },
       },
       {
@@ -90,6 +96,9 @@ export default {
             data: { id: 2, type: "user" },
           },
         },
+        meta: {
+          resourceMetaForGet: "ok",
+        },
       },
     ],
   },
@@ -100,6 +109,9 @@ export default {
       attributes: {
         body: "this is test 1",
         voteCount: 2,
+      },
+      meta: {
+        resourceMetaForGet: "ok",
       },
       relationships: {
         author: {

--- a/tests/test-suite/acceptance/factories/nestedResources.ts
+++ b/tests/test-suite/acceptance/factories/nestedResources.ts
@@ -12,6 +12,9 @@ export default {
         relationships: {
           ...getExtraRelationships(users, "author")([1], "Object"),
         },
+        meta: {
+          resourceMetaForGet: "ok",
+        },
       },
       included: [getFactoryObject(users)(1), ...getFactoryObjects(votes)([1, 2])],
     },

--- a/tests/test-suite/acceptance/factories/utils.ts
+++ b/tests/test-suite/acceptance/factories/utils.ts
@@ -1,29 +1,32 @@
 import { Resource, ResourceRelationships } from "../../../../src";
 
 export const getFactoryObject =
-  (array: any[], key: string = "id") =>
+  (array: any[], key = "id") =>
   (id: string | number): Resource =>
     array.find((object) => object[key] == id);
 
 export const getFactoryObjects =
-  (array: any[], key: string = "id") =>
+  (array: any[], key = "id") =>
   (ids: (string | number)[]): Resource[] =>
     array.filter((object) => ids.includes(object[key]));
 
 export const getExtraRelationships =
-  (array: any[], relationshipName?: string, key: string = "id") =>
+  (array: any[], relationshipName?: string, key = "id") =>
   (ids: (string | number)[], format: "Array" | "Object" = "Array"): ResourceRelationships => {
-    const relationship =
-      format === "Object"
-        ? {
-            id: getFactoryObject(array, key)(ids[0]).id,
+    if (format === "Object") {
+      return {
+        [relationshipName!]: {
+          data: {
+            id: getFactoryObject(array, key)(ids[0]).id as string,
             type: getFactoryObject(array, key)(ids[0]).type,
-          }
-        : getFactoryObjects(array, key)(ids).map(({ id, type }) => ({ id, type }));
+          },
+        },
+      };
+    }
 
     return {
-      [relationshipName]: {
-        data: relationship,
+      [relationshipName!]: {
+        data: getFactoryObjects(array, key)(ids).map(({ id, type }) => ({ id, type } as { id: string; type: string })),
       },
     };
   };

--- a/tests/test-suite/acceptance/helpers/transportLayers.ts
+++ b/tests/test-suite/acceptance/helpers/transportLayers.ts
@@ -23,7 +23,7 @@ const transportLayerContext = {
 
 export const transportLayers = Object.keys(transportLayerContext).map((layer) => [layer]);
 
-export default function testTransportLayer(transportLayer?: string) {
+export default function testTransportLayer(transportLayer: string) {
   const { app, agent } = transportLayerContext[transportLayer];
   const request = superagentDefaults(agent(app));
 
@@ -35,7 +35,7 @@ export default function testTransportLayer(transportLayer?: string) {
   return request;
 }
 
-export function testTransportLayerWithStrictError(transportLayer?: string) {
+export function testTransportLayerWithStrictError(transportLayer: string) {
   const { app, agent } = transportLayerContext[transportLayer];
   const request = superagentDefaults(agent(app));
 

--- a/tests/test-suite/test-app/processors/article.ts
+++ b/tests/test-suite/test-app/processors/article.ts
@@ -1,9 +1,69 @@
-import { KnexProcessor, HasId } from "../kurier";
+import { KnexProcessor, HasId, MaybeMeta, Operation } from "../kurier";
 import Article from "../resources/article";
 import Vote from "../resources/vote";
 
 export default class ArticleProcessor<ResourceT extends Article> extends KnexProcessor<ResourceT> {
   static resourceClass = Article;
+
+  async meta(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      meta: "ok",
+    };
+  }
+
+  async metaFor(op: Operation, resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      metaFor: op.op,
+    };
+  }
+
+  async metaForAdd(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      metaForAdd: "ok",
+    };
+  }
+
+  async metaForUpdate(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      metaForUpdate: "ok",
+    };
+  }
+
+  async metaForGet(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
+    return {
+      metaForGet: "ok",
+    };
+  }
+
+  async resourceMeta(resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMeta: "ok",
+    };
+  }
+
+  async resourceMetaFor(op: Operation, resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMetaFor: op.op,
+    };
+  }
+
+  async resourceMetaForAdd(resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMetaForAdd: "ok",
+    };
+  }
+
+  async resourceMetaForUpdate(resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMetaForUpdate: "ok",
+    };
+  }
+
+  async resourceMetaForGet(resource: ResourceT): Promise<MaybeMeta> {
+    return {
+      resourceMetaForGet: "ok",
+    };
+  }
 
   attributes = {
     async voteCount(this: ArticleProcessor<Article>, article: HasId) {

--- a/tests/test-suite/test-app/processors/article.ts
+++ b/tests/test-suite/test-app/processors/article.ts
@@ -5,60 +5,6 @@ import Vote from "../resources/vote";
 export default class ArticleProcessor<ResourceT extends Article> extends KnexProcessor<ResourceT> {
   static resourceClass = Article;
 
-  async meta(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      meta: "ok",
-    };
-  }
-
-  async metaFor(op: Operation, resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      metaFor: op.op,
-    };
-  }
-
-  async metaForAdd(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      metaForAdd: "ok",
-    };
-  }
-
-  async metaForUpdate(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      metaForUpdate: "ok",
-    };
-  }
-
-  async metaForGet(resourceOrResources: ResourceT | ResourceT[]): Promise<MaybeMeta> {
-    return {
-      metaForGet: "ok",
-    };
-  }
-
-  async resourceMeta(resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMeta: "ok",
-    };
-  }
-
-  async resourceMetaFor(op: Operation, resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMetaFor: op.op,
-    };
-  }
-
-  async resourceMetaForAdd(resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMetaForAdd: "ok",
-    };
-  }
-
-  async resourceMetaForUpdate(resource: ResourceT): Promise<MaybeMeta> {
-    return {
-      resourceMetaForUpdate: "ok",
-    };
-  }
-
   async resourceMetaForGet(resource: ResourceT): Promise<MaybeMeta> {
     return {
       resourceMetaForGet: "ok",


### PR DESCRIPTION
This PR implements the `meta` hook API described in #326, allowing to add metadata objects both at resource-level and document-level, as described in the JSON:API spec:

- [Document meta](https://jsonapi.org/format/#document-meta)
- [Resource objects](https://jsonapi.org/format/#document-resource-objects)

This PR does not include support for `meta` in `links`, since #243 is still not available.