### PR TITLE
Adding handling for strict mode in koa and vercel middlewares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 test.sqlite3
 test.sqlite3-journal
 junit.xml
+.idea

--- a/src/middlewares/json-api-koa.ts
+++ b/src/middlewares/json-api-koa.ts
@@ -37,6 +37,9 @@ export default function jsonApiKoa(
   };
 
   const jsonApiKoa = async (ctx: Context, next: () => Promise<any>) => {
+    if (httpStrictMode && ctx.status === 400) {
+      return next();
+    }
     const appInstance = new ApplicationInstance(app);
 
     try {

--- a/src/middlewares/json-api-vercel.ts
+++ b/src/middlewares/json-api-vercel.ts
@@ -44,6 +44,9 @@ export default function jsonApiVercel(
 ) {
   return async (req: VercelRequest, res: VercelResponse) => {
     await checkStrictMode(transportLayerOptions, req, res);
+    if (transportLayerOptions.httpStrictMode && res.statusCode === 400) {
+      return;
+    }
     const appInstance = new ApplicationInstance(app);
 
     try {

--- a/tests/test-suite/acceptance/helpers/transportLayers.ts
+++ b/tests/test-suite/acceptance/helpers/transportLayers.ts
@@ -34,3 +34,15 @@ export default function testTransportLayer(transportLayer?: string) {
 
   return request;
 }
+
+export function testTransportLayerWithStrictError(transportLayer?: string) {
+  const { app, agent } = transportLayerContext[transportLayer];
+  const request = superagentDefaults(agent(app));
+
+  request.use(supertestPrefix(`/${kurierApp.namespace}`));
+  request.use((req: supertest.Request) => {
+    req.set("Content-Type", "application/json");
+  });
+
+  return request;
+}

--- a/tests/test-suite/acceptance/httpStrictMode.test.ts
+++ b/tests/test-suite/acceptance/httpStrictMode.test.ts
@@ -1,0 +1,27 @@
+import getAuthenticationData from "./helpers/authenticateUser";
+
+import testTransportLayer, { testTransportLayerWithStrictError, transportLayers } from "./helpers/transportLayers";
+
+describe.each(transportLayers)("Transport Layer: %s", (transportLayer) => {
+  const requestWithError = testTransportLayerWithStrictError(transportLayer);
+  const request = testTransportLayer(transportLayer);
+  describe("Test transport layer", () => {
+    describe("Request without application/vnd.api+json content-type", () => {
+      it("Random endpoint with wrong content-type", async () => {
+        const authData = await getAuthenticationData();
+        const result = await requestWithError.get("/users").set("Authorization", authData.token);
+        expect(result.status).toEqual(400);
+        expect(JSON.stringify(result.body)).toMatch("Content-Type must be application/vnd.api+json");
+      });
+    });
+
+    describe("Request with application/vnd.api+json content-type", () => {
+      it("Random endpoint with correct content-type", async () => {
+        const result = await request.get("/random/number");
+        expect(result.status).toEqual(200);
+        expect(result.body.data.attributes).toHaveProperty("randomNumber");
+        expect(result.body.data.attributes.randomNumber).toBeGreaterThan(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
When using Koa and Vercel middlewares, If you set to strict mode and send an invalid content-type header, the lib is not returning the error message before starting processing. This pull request fixes it.