### PR TITLE
Implement hooks for addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ _Note: This example assumes a TypeScript environment with several dependencies p
    const app = new Application({
      namespace: "api",
      types: [Author],
-     defaultProcessor: new KnexProcessor(/* your knex DB connection settings */)
+     defaultProcessor: new KnexProcessor(/* your knex DB connection settings */),
    });
 
    const api = new Koa();
@@ -110,6 +110,11 @@ Extend Kurier's features with these addons:
 - [`@kurier/addon-many-to-many`](https://github.com/kurierjs/kurier-addon-many-to-many) creates intermediate resource types for many-to-many relationships.
 - [`@kurier/addon-auto-include`](https://github.com/kurierjs/kurier-addon-auto-include) alters GET operations to automatically include relationships.
 - [`@kurier/addon-nextjs-auth0`](https://github.com/kurierjs/kurier-addon-nextjs-auth0) integrates authorization mechanisms provided by [`nextjs-auth0`](https://github.com/auth0/nextjs-auth0) into Kurier.
+- [`@kurier/addon-transport-layer-context`](https://github.com/kurierjs/kurier-addon-transport-layer-context) allows Kurier processors to know the client's IP address and request headers via ApplicationInstance.
+
+## Build your own addon!
+
+We've created a template repository for developers who want to build their own addons. Check it out [here](https://github.com/kurierjs/kurier-addon-starter)!
 
 ## Starter packs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,8 @@ A TypeScript framework to create APIs following the [1.1 Spec of JSONAPI](https:
 - [Extending the framework](#extending-the-framework)
   - [What is an addon?](#what-is-an-addon)
   - [Using an addon](#using-an-addon)
+  - [Official addons](#official-addons)
+  - [Build your own addon](#build-your-own-addon)
 
 ## Getting started
 
@@ -945,20 +947,6 @@ class CommentProcessor<T extends Comment> extends KnexProcessor<T> {
 
 Any computed properties you define will be included in the resource on any operation. **Do not** declare these computed properties in the resource's schema, as Kurier will interpret them as columns in a table and fail due to non-existing columns.
 
-### The transport layer context
-
-As you may have noticed, Kurier takes separation of concerns quite seriously, and allows no interactions between say, the HTTP transport layer and a processor. However, there are a _few_ use cases where you might need, for instance, the client's IP address, such as geocoding. Since launch, all processors in Kurier holds an `appInstance` property, a reference to the current instance of the application, where an operation is taking place. Starting from version 1.3.0, we've added a `transportLayerContext` with two properties, available depending on what you're using (Express, Koa, Vercel or WebSockets):
-
-- `ip`: a `string` containing the remote client's IP address (it could be IPv4, IPv6, it could come from `remoteAddress` or from the `X-Forwarded-For` header, it really depends on the transport middleware you're using).
-- `headers`: a `dictionary` containing all available headers from the original request (it works both for HTTP and WebSockets, information available may vary according to the protocol you're using).
-
-You can access this information at any given point in your processor like this:
-
-```ts
-const { ip, headers } = this.appInstance.transportLayerContext;
-// Do stuff with ip and/or headers...
-```
-
 ## The `KnexProcessor` class
 
 This processor is a fully-implemented, database-driven extension of the `OperationProcessor` class seen before. It takes care of creating the necessary SQL queries to resolve any given operation.
@@ -1228,7 +1216,7 @@ For example, a role provider could look like this:
 ```ts
 import { ApplicationInstance, User } from "kurier";
 
-export default async function roleProvider(this: ApplicationInstance, user: User): Promise<string[]> {
+export default async function roleProvider(this: ApplicationInstanceInterface, user: User): Promise<string[]> {
   const userRoleProcessor = this.processorFor("userRole");
 
   return (await roleProcessor.getQuery().where({ user_id: user.id }).select("role_name")).map(
@@ -1380,7 +1368,7 @@ You can build an addon by deriving a new class extending from the `Addon` primit
 
 ```ts
 export default class MyAddon extends Addon {
-  constructor(public readonly app: Application, public readonly options?: MyAddonOptions) {
+  constructor(public readonly app: ApplicationInterface, public readonly options?: MyAddonOptions) {
     super(app, options);
   }
 
@@ -1407,6 +1395,19 @@ app.use(MyAddon, {
   foo: 3,
 } as MyAddonOptions);
 ```
+
+### Official addons
+
+Extend Kurier's features with these addons:
+
+- [`@kurier/addon-many-to-many`](https://github.com/kurierjs/kurier-addon-many-to-many) creates intermediate resource types for many-to-many relationships.
+- [`@kurier/addon-auto-include`](https://github.com/kurierjs/kurier-addon-auto-include) alters GET operations to automatically include relationships.
+- [`@kurier/addon-nextjs-auth0`](https://github.com/kurierjs/kurier-addon-nextjs-auth0) integrates authorization mechanisms provided by [`nextjs-auth0`](https://github.com/auth0/nextjs-auth0) into Kurier.
+- [`@kurier/addon-transport-layer-context`](https://github.com/kurierjs/kurier-addon-transport-layer-context) allows Kurier processors to know the client's IP address and request headers via ApplicationInstance.
+
+### Build your own addon!
+
+We've created a template repository for developers who want to build their own addons. Check it out [here](https://github.com/kurierjs/kurier-addon-starter)!
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ A TypeScript framework to create APIs following the [1.1 Spec of JSONAPI](https:
   - [Using an addon](#using-an-addon)
   - [Official addons](#official-addons)
   - [Build your own addon](#build-your-own-addon)
+  - [Using hooks][#using-hooks]
 
 ## Getting started
 
@@ -1408,6 +1409,38 @@ Extend Kurier's features with these addons:
 ### Build your own addon!
 
 We've created a template repository for developers who want to build their own addons. Check it out [here](https://github.com/kurierjs/kurier-addon-starter)!
+
+### Using hooks
+
+Hooks are a basic way for addons to extend behavior in the request-response pipeline, at the middleware layer.
+
+The following hooks are supported:
+
+- `beforeAuthentication` - triggered before calling the `authenticate()` method on any transport layer.
+- `beforeRequestHandling` - triggered before calling the `handleBulkEndpoint()` or `handleJsonApiEndpoint()` methods on any transport layer.
+
+A hook can be registered from the `app` object, which receives two parameters: the `appInstance` and a hash containing a variety of properties. For example:
+
+```ts
+app.hook("beforeAuthentication", async (appInstance: ApplicationInstanceInterface, parameters: Record<string, any>) => {
+  // Do your magic here.
+});
+
+app.hook(
+  "beforeRequestHandling",
+  async (appInstance: ApplicationInstanceInterface, parameters: Record<string, any>) => {
+    // Do your magic here.
+  },
+);
+```
+
+At the moment, `parameters` is comprised of:
+
+- `headers` - a collection of all the headers provided by the request.
+- `connection` - a legacy object used to obtain information about the client's connection.
+- `socket` - a built-in property of the `http` module, which refers to the underlying socket supporting the connection.
+
+You can register as many hook functions as you need by calling `app.hook` for each hook function you define.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kurier",
-  "version": "1.3.0-beta1",
+  "version": "1.3.0-beta2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,8 +39,8 @@
     "ember-cli-string-utils": "^1.1.0",
     "escape-string-regexp": "^4.0.0",
     "express": "^4.18.1",
-    "jsonwebtoken": "^9.0.0",
     "inflection": "^1.13.4",
+    "jsonwebtoken": "^9.0.0",
     "knex": "^2.3.0",
     "koa": "2.13.4",
     "koa-body": "^5.0.0",

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1,8 +1,7 @@
-import Application from "./application";
-import { IAddon, AddonOptions } from "./types";
+import { IAddon, AddonOptions, ApplicationInterface } from "./types";
 
 export default class Addon implements IAddon {
-  constructor(public readonly app: Application, public readonly options?: AddonOptions) {
+  constructor(public readonly app: ApplicationInterface, public readonly options?: AddonOptions) {
     this.app = app;
     this.options = options;
   }

--- a/src/addons/user-management.ts
+++ b/src/addons/user-management.ts
@@ -1,5 +1,11 @@
 import Addon from "../addon";
-import { AddonOptions, Operation, ResourceAttributes } from "../types";
+import {
+  AddonOptions,
+  ApplicationInstanceInterface,
+  ApplicationInterface,
+  Operation,
+  ResourceAttributes,
+} from "../types";
 import User from "../resources/user";
 import Application from "../application";
 import Password from "../attribute-types/password";
@@ -7,7 +13,6 @@ import Resource from "../resource";
 import JsonApiUserProcessor from "../processors/user-processor";
 import JsonApiSessionProcessor from "../processors/session-processor";
 import Session from "../resources/session";
-import ApplicationInstance from "../application-instance";
 
 export type UserManagementAddonOptions = AddonOptions & {
   userResource: typeof User;
@@ -15,8 +20,8 @@ export type UserManagementAddonOptions = AddonOptions & {
   userEncryptPasswordCallback?: (op: Operation) => Promise<ResourceAttributes>;
   userLoginCallback?: (op: Operation, userDataSource: ResourceAttributes) => Promise<boolean>;
   userGenerateIdCallback?: () => Promise<string>;
-  userRolesProvider?: (this: ApplicationInstance, user: User) => Promise<string[]>;
-  userPermissionsProvider?: (this: ApplicationInstance, user: User) => Promise<string[]>;
+  userRolesProvider?: (this: ApplicationInstanceInterface, user: User) => Promise<string[]>;
+  userPermissionsProvider?: (this: ApplicationInstanceInterface, user: User) => Promise<string[]>;
   usernameRequestParameter?: string;
   passwordRequestParameter?: string;
 };
@@ -48,7 +53,7 @@ const defaults: UserManagementAddonOptions = {
 
 export default class UserManagementAddon extends Addon {
   constructor(
-    public readonly app: Application,
+    public readonly app: ApplicationInterface,
     public readonly options: UserManagementAddonOptions = {} as UserManagementAddonOptions,
   ) {
     super(app);

--- a/src/application-instance.ts
+++ b/src/application-instance.ts
@@ -1,19 +1,17 @@
 import { decode } from "jsonwebtoken";
 import { Knex } from "knex";
 
-import Application from "./application";
 import Resource from "./resource";
 import OperationProcessor from "./processors/operation-processor";
-import { Operation, OperationResponse, NoOpTransaction, TransportLayerContext } from "./types";
+import { Operation, OperationResponse, NoOpTransaction, ApplicationInterface } from "./types";
 import jsonApiErrors from "./errors/json-api-errors";
 import User from "./resources/user";
 
 export default class ApplicationInstance {
   public user: User | undefined;
   public transaction: Knex.Transaction | NoOpTransaction;
-  public transportLayerContext: TransportLayerContext | undefined;
 
-  constructor(public app: Application) {}
+  constructor(public app: ApplicationInterface) {}
 
   async processorFor(resourceType: string): Promise<OperationProcessor<Resource> | undefined> {
     return this.app.processorFor(resourceType, this);

--- a/src/decorators/authorize.ts
+++ b/src/decorators/authorize.ts
@@ -1,10 +1,9 @@
 import JsonApiErrors from "../errors/json-api-errors";
-import { AttributeValueMatch, AttributeValue } from "../types";
+import { AttributeValueMatch, AttributeValue, ApplicationInstanceInterface } from "../types";
 
 import decorateWith from "./decorator";
 import OperationProcessor from "../processors/operation-processor";
 import Resource from "../resource";
-import ApplicationInstance from "../application-instance";
 
 type PrimitiveValue = string | number | boolean | object;
 
@@ -25,7 +24,7 @@ const every = (expected: AttributeValue[], actual: AttributeValue) => {
 };
 
 function conditionsPass(
-  appInstance: ApplicationInstance,
+  appInstance: ApplicationInstanceInterface,
   { attribute, value, operator = "some" }: AttributeValueMatch,
 ) {
   const actual: AttributeValue = appInstance.user?.attributes[attribute] as AttributeValue;
@@ -94,7 +93,7 @@ export default function authorize(...conditions: AttributeValueMatch[]) {
 export async function canAccessResource(
   resource: Resource | Resource[],
   operationName: string,
-  appInstance: ApplicationInstance,
+  appInstance: ApplicationInstanceInterface,
 ) {
   const type = Array.isArray(resource) && resource.length ? resource[0].type : (resource as Resource).type;
   const processor = (await appInstance.processorFor(type)) as OperationProcessor<Resource>;

--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -1,8 +1,8 @@
 import { Knex } from "knex";
-import ApplicationInstance from "../application-instance";
 import JsonApiErrors from "../errors/json-api-errors";
 import Resource from "../resource";
 import {
+  ApplicationInstanceInterface,
   DEFAULT_PRIMARY_KEY,
   EagerLoadedData,
   HasId,
@@ -77,7 +77,7 @@ const parseOperationIncludedRelationships = (
 export default class KnexProcessor<ResourceT extends Resource> extends OperationProcessor<ResourceT> {
   protected knex: Knex.Transaction;
 
-  constructor(appInstance: ApplicationInstance) {
+  constructor(appInstance: ApplicationInstanceInterface) {
     super(appInstance);
     this.knex = appInstance.transaction as Knex.Transaction;
   }

--- a/src/processors/operation-processor.ts
+++ b/src/processors/operation-processor.ts
@@ -1,8 +1,7 @@
 import Resource from "../resource";
-import { HasId, Operation, EagerLoadedData, MaybeMeta } from "../types";
+import { HasId, Operation, EagerLoadedData, MaybeMeta, ApplicationInstanceInterface } from "../types";
 import pick from "../utils/pick";
 import promiseHashMap from "../utils/promise-hash-map";
-import ApplicationInstance from "../application-instance";
 import JsonApiErrors from "../errors/json-api-errors";
 import { FunctionalOperators as operators, OperatorName } from "../utils/operators";
 
@@ -22,7 +21,7 @@ export default class OperationProcessor<ResourceT extends Resource> {
   protected attributes = {};
   protected relationships = {};
 
-  constructor(public appInstance: ApplicationInstance) {}
+  constructor(public appInstance: ApplicationInstanceInterface) {}
 
   async execute(op: Operation): Promise<ResourceT | ResourceT[] | void> {
     const action: string = op.op;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import ApplicationInstance from "./application-instance";
 import Password from "./attribute-types/password";
 import Resource from "./resource";
 import User from "./resources/user";
+import OperationProcessor from "./processors/operation-processor";
+import Application from "./application";
 
 export enum HttpStatusCode {
   OK = 200,
@@ -214,11 +216,6 @@ export type TransportLayerOptions = {
   httpStrictMode?: boolean;
 };
 
-export type TransportLayerContext = {
-  ip?: string;
-  headers?: IncomingHttpHeaders;
-};
-
 export type VercelRequest<BodyType = JsonApiDocument> = IncomingMessage & {
   query: Record<string, string | string[]>;
   cookies: Record<string, string>;
@@ -235,3 +232,16 @@ export type VercelResponse = ServerResponse & {
 export type JsonApiBulkResponse = { operations: OperationResponse[] };
 
 export type VendorRequest = ExpressRequest | KoaRequest | VercelRequest;
+
+export type HookFunction = (appInstance: ApplicationInstance, parameters?: Record<string, any>) => Promise<void>;
+
+export interface ApplicationHooks {
+  beforeAuthentication: HookFunction[];
+  beforeRequestHandling: HookFunction[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ApplicationInterface extends Application {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ApplicationInstanceInterface extends ApplicationInstance {}

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,16 @@
+import jsonApiErrors from "../errors/json-api-errors";
+import { ApplicationHooks, ApplicationInstanceInterface } from "../types";
+
+export const runHookFunctions = async (
+  appInstance: ApplicationInstanceInterface,
+  hookType: keyof ApplicationHooks,
+  parameters: Record<string, any> = {},
+) => {
+  for (const hook of appInstance.app.hooks[hookType]) {
+    try {
+      await hook(appInstance, parameters);
+    } catch (e) {
+      throw jsonApiErrors.UnhandledError(`Hook ${hookType}:${hook.name} failed: ${e.message}, ${e.stack}`);
+    }
+  }
+};

--- a/src/utils/http-utils.ts
+++ b/src/utils/http-utils.ts
@@ -1,6 +1,5 @@
 import * as escapeStringRegexp from "escape-string-regexp";
-import { JsonApiBulkResponse, VendorRequest } from "../types";
-import ApplicationInstance from "../application-instance";
+import { ApplicationInstanceInterface, JsonApiBulkResponse, VendorRequest } from "../types";
 import JsonApiError from "../errors/error";
 import JsonApiErrors from "../errors/json-api-errors";
 import User from "../resources/user";
@@ -17,7 +16,7 @@ const STATUS_MAPPING = {
   DELETE: 204,
 };
 
-async function authenticate(appInstance: ApplicationInstance, request: VendorRequest) {
+async function authenticate(appInstance: ApplicationInstanceInterface, request: VendorRequest) {
   const authHeader = request.headers.authorization;
   let currentUser: User | undefined;
 
@@ -29,7 +28,7 @@ async function authenticate(appInstance: ApplicationInstance, request: VendorReq
   appInstance.user = currentUser;
 }
 
-function urlData(appInstance: ApplicationInstance, path: string) {
+function urlData(appInstance: ApplicationInstanceInterface, path: string) {
   const urlRegexp = new RegExp(
     `^(\/+)?((?<namespace>${escapeStringRegexp(
       appInstance.app.namespace,
@@ -48,14 +47,14 @@ function urlData(appInstance: ApplicationInstance, path: string) {
 }
 
 async function handleBulkEndpoint(
-  appInstance: ApplicationInstance,
+  appInstance: ApplicationInstanceInterface,
   operations: Operation[],
 ): Promise<JsonApiBulkResponse> {
   return { operations: await appInstance.app.executeOperations(operations || [], appInstance) };
 }
 
 async function handleJsonApiEndpoint(
-  appInstance: ApplicationInstance,
+  appInstance: ApplicationInstanceInterface,
   request: VendorRequest,
 ): Promise<{ body: JsonApiDocument | JsonApiErrorsDocument; status: number }> {
   const op: Operation = convertHttpRequestToOperation(request);

--- a/tests/dummy-app/app.ts
+++ b/tests/dummy-app/app.ts
@@ -1,7 +1,7 @@
 import { knex } from "knex";
 import {
   Application,
-  ApplicationInstance,
+  ApplicationInstanceInterface,
   KnexProcessor,
   UserManagementAddon,
   UserManagementAddonOptions,
@@ -32,7 +32,7 @@ app.use(UserManagementAddon, {
   userResource: User,
   userProcessor: UserProcessor,
   userLoginCallback: login,
-  async userRolesProvider(this: ApplicationInstance, user: User) {
+  async userRolesProvider(this: ApplicationInstanceInterface, user: User) {
     return ["Admin"];
   },
   // userGenerateIdCallback: async () => (-Date.now()).toString(),

--- a/tests/test-suite/acceptance/article.test.ts
+++ b/tests/test-suite/acceptance/article.test.ts
@@ -57,21 +57,21 @@ describe.each(transportLayers)("Transport Layer: %s", (transportLayer) => {
       it("Meta - Get meta hooks response", async () => {
         const result = await request.get("/articles");
         expect(result.body.data[0].meta).toEqual({
-          ip: "::ffff:127.0.0.1",
+          hello: "world",
         });
       });
 
       it("Meta - meta hooks response in GET ALL", async () => {
         const result = await request.get("/articles");
         expect(result.body.data[0].meta).toEqual({
-          ip: "::ffff:127.0.0.1",
+          hello: "world",
         });
       });
 
       it("Meta - meta hooks response in GET by ID", async () => {
         const result = await request.get("/articles/1");
         expect(result.body.data.meta).toEqual({
-          ip: "::ffff:127.0.0.1",
+          hello: "world",
         });
       });
     });

--- a/tests/test-suite/acceptance/factories/article.ts
+++ b/tests/test-suite/acceptance/factories/article.ts
@@ -65,7 +65,7 @@ export default {
           },
         },
         meta: {
-          ip: "::ffff:127.0.0.1",
+          hello: "world",
         },
       },
       {
@@ -81,7 +81,7 @@ export default {
           },
         },
         meta: {
-          ip: "::ffff:127.0.0.1",
+          hello: "world",
         },
       },
       {
@@ -97,7 +97,7 @@ export default {
           },
         },
         meta: {
-          ip: "::ffff:127.0.0.1",
+          hello: "world",
         },
       },
     ],
@@ -111,7 +111,7 @@ export default {
         voteCount: 2,
       },
       meta: {
-        ip: "::ffff:127.0.0.1",
+        hello: "world",
       },
       relationships: {
         author: {

--- a/tests/test-suite/acceptance/factories/nestedResources.ts
+++ b/tests/test-suite/acceptance/factories/nestedResources.ts
@@ -13,7 +13,7 @@ export default {
           ...getExtraRelationships(users, "author")([1], "Object"),
         },
         meta: {
-          ip: "::ffff:127.0.0.1",
+          hello: "world",
         },
       },
       included: [getFactoryObject(users)(1), ...getFactoryObjects(votes)([1, 2])],

--- a/tests/test-suite/test-app/app.ts
+++ b/tests/test-suite/test-app/app.ts
@@ -1,7 +1,7 @@
 import { knex } from "knex";
 import {
   Application,
-  ApplicationInstance,
+  ApplicationInstanceInterface,
   KnexProcessor,
   UserManagementAddon,
   UserManagementAddonOptions,
@@ -33,7 +33,7 @@ app.use(UserManagementAddon, {
   userResource: User,
   userProcessor: UserProcessor,
   userLoginCallback: login,
-  async userRolesProvider(this: ApplicationInstance, user: User) {
+  async userRolesProvider(this: ApplicationInstanceInterface, user: User) {
     return ["Admin"];
   },
 } as UserManagementAddonOptions);

--- a/tests/test-suite/test-app/processors/article.ts
+++ b/tests/test-suite/test-app/processors/article.ts
@@ -7,7 +7,7 @@ export default class ArticleProcessor<ResourceT extends Article> extends KnexPro
 
   async resourceMetaForGet(resource: ResourceT): Promise<MaybeMeta> {
     return {
-      ip: this.appInstance.transportLayerContext?.ip as string,
+      hello: "world",
     };
   }
 

--- a/tests/test-suite/unit/application.test.ts
+++ b/tests/test-suite/unit/application.test.ts
@@ -1,14 +1,32 @@
-import { KnexProcessor, Application } from "../../../src";
+import { KnexProcessor, Application, ApplicationInstanceInterface } from "../../../src";
 
 describe("Application", () => {
-  it("can be instantiated", async () => {
-    const app = new Application({
+  let app: Application;
+
+  beforeEach(() => {
+    app = new Application({
       namespace: "api",
       types: [],
       processors: [],
       defaultProcessor: KnexProcessor,
     });
+  });
 
+  it("can be instantiated", async () => {
     expect(app).not.toBeNull();
+  });
+
+  it("can attach hooks", async () => {
+    const hook = async (appInstance: ApplicationInstanceInterface) => {
+      expect(appInstance).toBeDefined();
+    };
+
+    app.hook("beforeAuthentication", hook);
+    app.hook("beforeRequestHandling", hook);
+
+    expect(app.hooks.beforeAuthentication).toHaveLength(1);
+    expect(app.hooks.beforeRequestHandling).toHaveLength(1);
+    expect(app.hooks.beforeAuthentication[0]).toEqual(hook);
+    expect(app.hooks.beforeRequestHandling[0]).toEqual(hook);
   });
 });


### PR DESCRIPTION
Hooks are a basic way for addons to extend behavior in the request-response pipeline, at the middleware layer.

The following hooks are supported:

- `beforeAuthentication` - triggered before calling the `authenticate()` method on any transport layer.
- `beforeRequestHandling` - triggered before calling the `handleBulkEndpoint()` or `handleJsonApiEndpoint()` methods on any transport layer.

A hook can be registered from the `app` object, which receives two parameters: the `appInstance` and a hash containing a variety of properties. For example:

```ts
app.hook('beforeAuthentication', async (appInstance: ApplicationInstanceInterface, parameters: Record<string, any>) => {
  // Do your magic here.
});

app.hook('beforeRequestHandling', async (appInstance: ApplicationInstanceInterface, parameters: Record<string, any>) => {
  // Do your magic here.
});
```

At the moment, `parameters` is comprised of:

- `headers` - a collection of all the headers provided by the request.
- `connection` - a legacy object used to obtain information about the client's connection.
- `socket` - a built-in property of the `http` module, which refers to the underlying socket supporting the connection.

You can register as many hook functions as you need by calling `app.hook` for each hook function you define.