### PR TITLE
New hook: beforeExecutingIdentifyOperation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kurier",
-  "version": "1.3.0-beta6",
+  "version": "1.3.0-beta7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kurier",
-      "version": "1.3.0-beta6",
+      "version": "1.3.0-beta7",
       "license": "MIT",
       "dependencies": {
         "compose-middleware": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kurier",
-  "version": "1.3.0-beta6",
+  "version": "1.3.0-beta7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/addons/user-management.ts
+++ b/src/addons/user-management.ts
@@ -26,6 +26,7 @@ export type UserManagementAddonOptions = AddonOptions & {
   usernameRequestParameter?: string;
   passwordRequestParameter?: string;
   jwtClaimForUserID?: string;
+  includeTokenInIdentifyOpDataPayload?: boolean;
 };
 
 const defaults: UserManagementAddonOptions = {
@@ -53,6 +54,7 @@ const defaults: UserManagementAddonOptions = {
   usernameRequestParameter: "username",
   passwordRequestParameter: "password",
   jwtClaimForUserID: "id",
+  includeTokenInIdentifyOpDataPayload: false,
 };
 
 export default class UserManagementAddon extends Addon {

--- a/src/application.ts
+++ b/src/application.ts
@@ -57,6 +57,7 @@ export default class Application {
     this.hooks = {
       beforeAuthentication: [],
       beforeRequestHandling: [],
+      beforeExecutingIdentifyOperation: [],
     };
 
     if (settings.attributeTypes) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,6 +252,7 @@ export type HookFunction = (appInstance: ApplicationInstance, parameters?: Recor
 export interface ApplicationHooks {
   beforeAuthentication: HookFunction[];
   beforeRequestHandling: HookFunction[];
+  beforeExecutingIdentifyOperation: HookFunction[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/utils/http-utils.ts
+++ b/src/utils/http-utils.ts
@@ -22,7 +22,7 @@ async function authenticate(appInstance: ApplicationInstanceInterface, request: 
 
   if (authHeader && authHeader.startsWith("Bearer ")) {
     const [, token] = authHeader.split(" ");
-    currentUser = await appInstance.getUserFromToken(token);
+    currentUser = await appInstance.getUserFromToken(token, request);
   }
 
   appInstance.user = currentUser;

--- a/tests/test-suite/unit/application.test.ts
+++ b/tests/test-suite/unit/application.test.ts
@@ -23,10 +23,13 @@ describe("Application", () => {
 
     app.hook("beforeAuthentication", hook);
     app.hook("beforeRequestHandling", hook);
+    app.hook("beforeExecutingIdentifyOperation", hook);
 
     expect(app.hooks.beforeAuthentication).toHaveLength(1);
     expect(app.hooks.beforeRequestHandling).toHaveLength(1);
+    expect(app.hooks.beforeExecutingIdentifyOperation).toHaveLength(1);
     expect(app.hooks.beforeAuthentication[0]).toEqual(hook);
     expect(app.hooks.beforeRequestHandling[0]).toEqual(hook);
+    expect(app.hooks.beforeExecutingIdentifyOperation[0]).toEqual(hook);
   });
 });


### PR DESCRIPTION
This hook allows you to modify the payload of the `identify` operation executed by `UserProcessor` to inject additional information you might need to query your user data (specially when Kurier isn't in control of the data and requires to login to an external API).