### PR TITLE
fix: type of params.page.*

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export type JsonApiParams = {
   include?: string[];
   sort?: string[];
   filter?: { [key: string]: string };
-  page?: { [key: string]: number };
+  page?: { [key: string]: string };
   fields?: { [key: string]: string[] };
 };
 


### PR DESCRIPTION
Those values are actually strings.

```
?page[limit]=19&page[number]=19&page[after:id]=SayLOC5U5pMj2KQlxCo0
```

```js


{page: { limit: '19', number: '19', 'after:id': 'SayLOC5U5pMj2KQlxCo0' }}
```