### PR TITLE
fix(json-api-express): make sure response status is a number

### DIFF
--- a/src/middlewares/json-api-express.ts
+++ b/src/middlewares/json-api-express.ts
@@ -51,7 +51,7 @@ export default function jsonApiExpress(
     try {
       await authenticate(appInstance, req);
     } catch (error) {
-      res.status(+error.status).json(convertErrorToHttpResponse(error));
+      res.status(Number(error.status)).json(convertErrorToHttpResponse(error));
       return next();
     }
 

--- a/src/middlewares/json-api-express.ts
+++ b/src/middlewares/json-api-express.ts
@@ -51,7 +51,7 @@ export default function jsonApiExpress(
     try {
       await authenticate(appInstance, req);
     } catch (error) {
-      res.status(Number(error.status)).json(convertErrorToHttpResponse(error));
+      res.status(+error.status).json(convertErrorToHttpResponse(error));
       return next();
     }
 

--- a/src/middlewares/json-api-express.ts
+++ b/src/middlewares/json-api-express.ts
@@ -51,7 +51,7 @@ export default function jsonApiExpress(
     try {
       await authenticate(appInstance, req);
     } catch (error) {
-      res.status(error.status).json(convertErrorToHttpResponse(error));
+      res.status(+error.status).json(convertErrorToHttpResponse(error));
       return next();
     }
 


### PR DESCRIPTION
Regardless of Error instance has `status` property as string, convert it to number for `res.status()`.

Fixes #369