### PR TITLE
fix/multiple.includes.nestedResources

### DIFF
--- a/src/processors/knex-processor.ts
+++ b/src/processors/knex-processor.ts
@@ -66,6 +66,7 @@ const parseOperationIncludedRelationships = (
     .filter((include) => include.length > 1)
     .reduce((acumRelationships, [nestedOrigin, nestedRelationshipName]) => {
       acumRelationships[nestedOrigin] = {
+        ...acumRelationships[nestedOrigin],
         [nestedRelationshipName]: relationships[nestedOrigin].type().schema.relationships[nestedRelationshipName],
       };
       return acumRelationships;

--- a/src/serializers/serializer.ts
+++ b/src/serializers/serializer.ts
@@ -294,8 +294,6 @@ export default class JsonApiSerializer implements IJsonApiSerializer {
           }
         },
       );
-    return [...new Set(includedData.map((item: Resource) => `${item.type}_${item.id}`))].map((typeId) =>
-      includedData.find((item: Resource) => `${item.type}_${item.id}` === typeId),
-    );
+    return includedData
   }
 }

--- a/tests/test-suite/acceptance/factories/nestedResources.ts
+++ b/tests/test-suite/acceptance/factories/nestedResources.ts
@@ -35,5 +35,17 @@ export default {
       data: getFactoryObject(comments)(1),
       included: [getFactoryObject(comments)(2), getFactoryObject(comments)(3)],
     },
+    authorAndAuthorVotesAndAuthorCommentsOf1stArticle: {
+      data: {
+        ...getFactoryObject(articles)(1),
+        relationships: {
+          ...getExtraRelationships(users, "author")([1], "Object"),
+        },
+        meta: {
+          hello: "world",
+        },
+      },
+      included: [getFactoryObject(users)(1), ...getFactoryObjects(votes)([1, 2]), ...getFactoryObjects(comments)([1, 3])],
+    },
   },
 };

--- a/tests/test-suite/acceptance/nestedResources.test.ts
+++ b/tests/test-suite/acceptance/nestedResources.test.ts
@@ -38,6 +38,13 @@ describe.each(transportLayers)("Transport Layer: %s", (transportLayer) => {
         expect(result.status).toEqual(200);
         expect(result.body).toEqual(nested.get.parentCommentAndParentCommentsParentCommentOf1stComment);
       });
+
+      it("Get the 1st article'Author's Votes and Comments (*-1-*)", async () => {
+        const authData = await getAuthenticationData();
+        const result = await request.get("/articles/1?include=author.votes,author.comments").set("Authorization", authData.token);
+        expect(result.status).toEqual(200);
+        expect(result.body).toEqual(nested.get.authorAndAuthorVotesAndAuthorCommentsOf1stArticle);
+      });
     });
   });
 });


### PR DESCRIPTION
This Pull Request introduces several changes to address a key issue and improve the functionality and testing of the application:

**Problem Solved**: The application was previously unable to handle queries for a resource with multiple nested resources simultaneously. If multiple nested resources were included in the query, only the last one was returned. This issue has been resolved with the changes in this PR.

1. **Enhancement in `knex-processor.ts`**: The `parseOperationIncludedRelationships` function has been updated to ensure that the `acumRelationships` object correctly accumulates relationships without overwriting existing ones. This is achieved by spreading the existing relationships before adding a new one. This change is part of the solution to the problem described above.

2. **Refactoring in `serializer.ts`**: The serialization process has been simplified. Previously, the code was creating a new array with unique `type_id` combinations from `includedData` and then mapping over this array to find the corresponding items in `includedData`. This has been replaced with a direct return of `includedData`, which simplifies the code and may improve performance.

3. **Addition of a new test in `nestedResources.test.ts`**: A new test has been added to verify the correct retrieval of the first article's author's votes and comments. This test will help ensure that the application's data retrieval and serialization processes are working as expected, and that multiple nested resources can be retrieved simultaneously.
