### PR TITLE
feat/add.ilike.operator

### DIFF
--- a/src/utils/operators.ts
+++ b/src/utils/operators.ts
@@ -1,4 +1,4 @@
-export type OperatorName = "eq" | "ne" | "lt" | "gt" | "le" | "ge" | "like" | "nlike" | "in" | "nin";
+export type OperatorName = "eq" | "ne" | "lt" | "gt" | "le" | "ge" | "like" | "nlike" | "ilike"| "in" | "nin";
 
 export const KnexOperators = {
   eq: "=",
@@ -9,6 +9,7 @@ export const KnexOperators = {
   ge: ">=",
   like: "like",
   nlike: "not like",
+  ilike: "ilike",
   in: "in",
   nin: "not in",
 };
@@ -46,6 +47,21 @@ export const FunctionalOperators: { [T in OperatorName]: (actual: any, expected:
 
     if (expected.endsWith("%")) {
       return !actual.startsWith(expected.replace(/%/g, ""));
+    }
+
+    return false;
+  },
+  ilike: (actual: string, expected: string) => {
+    if (expected.startsWith("%") && expected.endsWith("%")) {
+      return actual.includes(expected.replace(/%/g, ""));
+    }
+
+    if (expected.startsWith("%")) {
+      return actual.endsWith(expected.replace(/%/g, ""));
+    }
+
+    if (expected.endsWith("%")) {
+      return actual.startsWith(expected.replace(/%/g, ""));
     }
 
     return false;


### PR DESCRIPTION
This PR introduces support for the `ilike` operator in our application. The `ilike` operator is a case-insensitive version of the `like` operator, commonly used in PostgreSQL.

Changes:

1. The `OperatorName` type has been extended to include `"ilike"`. This allows us to use the `ilike` operator in our application logic.

2. The `KnexOperators` constant has been updated to map the `"ilike"` string to `"ilike"`. This ensures that the `ilike` operator is correctly translated when building queries with Knex.

3. A new `ilike` function has been added to the `FunctionalOperators` object. This function implements the logic for the `ilike` operator. It checks if the `expected` string starts with, ends with, or contains the `actual` string, taking into account the `%` wildcard character.

By adding support for the `ilike` operator, we can perform case-insensitive pattern matching in our queries, improving the flexibility and robustness of our application.