### PR TITLE
Fix CI workflow 

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,19 +12,18 @@ jobs:
         node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         check-latest: true
         cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
     - name: npm 9
       run: npm i -g npm@9 --registry=https://registry.npmjs.org
-    - name: install dependencies
+    - name: Install dependencies
       run: npm ci
-    - name: build, and test the package
+    - name: Build, and test the package
       run: |
         npm run build
         npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   build:
@@ -19,7 +19,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         check-latest: true
         cache: 'npm'
-    - name: npm 9
+    - name: Update npm to version 9
       run: npm i -g npm@9 --registry=https://registry.npmjs.org
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
The CI started failing lately (see [this](https://github.com/kurierjs/kurier/actions/runs/14776744162/job/41487246288?pr=387)), which it's affecting [this PR](https://github.com/kurierjs/kurier/pull/387).

The cause is an outdated action in the CI workflow, as reported [here](https://github.com/actions/setup-node/issues/1275). This PR updates the actions used in the CI workflow, and fixes them.

You can see the successful run [here](https://github.com/kurierjs/kurier/actions/runs/14777616369?pr=389). 

The Checks of the PR, shows failures because it's also trying to run the original workflow from the `develop` branch (which is bugged). After merging this one into `main` this should fix CI runs for every other PR